### PR TITLE
Clean notebooks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
-*.ipynb filter=lfs diff=lfs merge=lfs -text
+*.ipynb filter=nbstrip_full
+*-preserve_output.ipynb filter=lfs diff=lfs merge=lfs -text
+

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,16 @@
+# to activate run, at the root of the repo,
+# git config --local include.path ../.gitconfig
+# see https://stackoverflow.com/a/18330114
+
+
+filter "nbstrip_full"]
+# install jq
+# see http://timstaley.co.uk/posts/making-git-and-jupyter-notebooks-play-nice/
+clean = "jq --indent 1 \
+        '(.cells[] | select(has(\"outputs\")) | .outputs) = []  \
+        | (.cells[] | select(has(\"execution_count\")) | .execution_count) = null  \
+        | .metadata = {\"language_info\": {\"name\": \"python\", \"pygments_lexer\": \"ipython3\"}} \
+        | .cells[].metadata = {} \
+        '"
+smudge = cat
+required = true

--- a/.gitconfig
+++ b/.gitconfig
@@ -3,7 +3,7 @@
 # see https://stackoverflow.com/a/18330114
 
 
-filter "nbstrip_full"]
+filter ["nbstrip_full"]
 # install jq
 # see http://timstaley.co.uk/posts/making-git-and-jupyter-notebooks-play-nice/
 clean = "jq --indent 1 \

--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - cudatoolkit
   - flake8
   - isort
+  - jq
   - jupyter
   - matplotlib
   - numpy

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
             "black",
             "flake8",
             "isort",
+            "jq",
             "pytest",
             "pyyaml",
             "torchtestcase",


### PR DESCRIPTION
I am trying to use jq for this.
Apparently one should deactivate this before rebases (http://timstaley.co.uk/posts/making-git-and-jupyter-notebooks-play-nice/). Not sure if the same argument applies to nbstripout (see below).

Another approach is nbstripout, but it is slow (comparison here: http://timstaley.co.uk/posts/making-git-and-jupyter-notebooks-play-nice/)

Two faster versions of nbstripout exist (with less features) here: https://github.com/stas00/jupyter-notebook-tools/tree/master/nbstripout, but they haven't been merged into nbstripout.