### PR TITLE
Update mdn.py: support when batch_x has only one single feature

### DIFF
--- a/pyknos/mdn/mdn.py
+++ b/pyknos/mdn/mdn.py
@@ -53,7 +53,8 @@ class MultivariateGaussianMDN(nn.Module):
         self._context_features = context_features
         self._hidden_features = hidden_features
         self._num_components = num_components
-        self._num_upper_params = (features * (features - 1)) // 2
+        
+        self._num_upper_params = (features * (features - 1)) // 2 if self._features > 1 else self._num_upper_params = 1
 
         self._row_ix, self._column_ix = np.triu_indices(features, k=1)
         self._diag_ix = range(features)

--- a/pyknos/mdn/mdn.py
+++ b/pyknos/mdn/mdn.py
@@ -54,7 +54,7 @@ class MultivariateGaussianMDN(nn.Module):
         self._hidden_features = hidden_features
         self._num_components = num_components
         
-        self._num_upper_params = (features * (features - 1)) // 2 if self._features > 1 else self._num_upper_params = 1
+        self._num_upper_params = (features * (features - 1)) // 2 
 
         self._row_ix, self._column_ix = np.triu_indices(features, k=1)
         self._diag_ix = range(features)
@@ -113,9 +113,7 @@ class MultivariateGaussianMDN(nn.Module):
         unconstrained_diagonal = self._unconstrained_diagonal_layer(h).view(
             -1, self._num_components, self._features
         )
-        upper = self._upper_layer(h).view(
-            -1, self._num_components, self._num_upper_params
-        )
+        
 
         # Elements of diagonal of precision factor must be positive
         # (recall precision factor A such that SIGMA^-1 = A^T A).
@@ -126,7 +124,13 @@ class MultivariateGaussianMDN(nn.Module):
             means.shape[0], self._num_components, self._features, self._features
         )
         precision_factors[..., self._diag_ix, self._diag_ix] = diagonal
-        precision_factors[..., self._row_ix, self._column_ix] = upper
+        
+        # one dimensional feature does not involve upper triangular parameters
+        if self._features > 1:
+            upper = self._upper_layer(h).view(
+                -1, self._num_components, self._num_upper_params
+            )
+            precision_factors[..., self._row_ix, self._column_ix] = upper
 
         # Precisions are given by SIGMA^-1 = A^T A.
         precisions = torch.matmul(


### PR DESCRIPTION
Hi! I was experimenting a toy dataset where observed data has only one feature (namely, probability p in Bernoulli distribution in my case), and I found that current implementation gives error because of the `feature - 1` term when we calculate the number of parameters in the upper triangular matrix. Not sure this is worth a PR but I think would be helpful. 
Thanks!