### PR TITLE
Mdn cleanup/deprecating hidden features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ target/
 
 # Editors
 .vscode/
+.idea/

--- a/pyknos/mdn/mdn.py
+++ b/pyknos/mdn/mdn.py
@@ -4,6 +4,7 @@ C. M. Bishop, "Mixture Density Networks", NCRG Report (1994)
 
 Taken from http://github.com/conormdurkan/lfi. See there for copyright.
 """
+import warnings
 from typing import Optional, Tuple
 
 import numpy as np
@@ -30,9 +31,9 @@ class MultivariateGaussianMDN(nn.Module):
         self,
         features: int,
         context_features: int,
-        hidden_features: int,
-        hidden_net: nn.Module,
-        num_components: int,
+        hidden_features: int = None,
+        hidden_net: nn.Module = None,
+        num_components: int = None,
         custom_initialization=False,
         embedding_net=None,
     ):
@@ -47,6 +48,18 @@ class MultivariateGaussianMDN(nn.Module):
             num_components: Number of mixture components.
             custom_initialization: XXX
         """
+
+        if hidden_net is None:
+            raise TypeError("__init__() missing 1 required positional argument: 'hidden_net'")
+        if num_components is None:
+            raise TypeError("__init__() missing 1 required positional argument: 'num_components'")
+
+        if hidden_features is not None:
+            msg = "'hidden_features' parameter is deprecated and will be removed in a future version.\n"
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
+
+        hidden_features = next((child.out_features for child in reversed(list(hidden_net.children())) if
+                                hasattr(child, 'out_features')), None)
 
         super().__init__()
 

--- a/pyknos/mdn/mdn.py
+++ b/pyknos/mdn/mdn.py
@@ -4,6 +4,7 @@ C. M. Bishop, "Mixture Density Networks", NCRG Report (1994)
 
 Taken from http://github.com/conormdurkan/lfi. See there for copyright.
 """
+import warnings
 from typing import Optional, Tuple
 
 import numpy as np
@@ -30,9 +31,9 @@ class MultivariateGaussianMDN(nn.Module):
         self,
         features: int,
         context_features: int,
-        hidden_features: int,
-        hidden_net: nn.Module,
-        num_components: int,
+        hidden_features: int = None,
+        hidden_net: nn.Module = None,
+        num_components: int = None,
         custom_initialization=False,
         embedding_net=None,
     ):
@@ -47,6 +48,18 @@ class MultivariateGaussianMDN(nn.Module):
             num_components: Number of mixture components.
             custom_initialization: XXX
         """
+
+        if hidden_net is None:
+            raise ValueError("Required parameter: `hidden_net` is not set")
+        if num_components is None:
+            raise ValueError("Required parameter: `num_components` is not set")
+
+        if hidden_features is not None:
+            msg = "'hidden_features' parameter is deprecated and will be removed in a future version.\n"
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
+
+        hidden_features = next((child.out_features for child in reversed(list(hidden_net.children())) if
+                                hasattr(child, 'out_features')), None)
 
         super().__init__()
 

--- a/pyknos/mdn/mdn.py
+++ b/pyknos/mdn/mdn.py
@@ -49,12 +49,24 @@ class MultivariateGaussianMDN(nn.Module):
             custom_initialization: XXX
         """
 
+        inferred_hidden_features = next(
+            (
+                child.out_features
+                for child in reversed(list(hidden_net.children()))
+                if hasattr(child, "out_features")
+            ),
+            None,
+        )
+
         if hidden_features is not None:
             msg = "'hidden_features' parameter is deprecated and will be removed in a future version.\n"
             warnings.warn(msg, DeprecationWarning, stacklevel=2)
-
-        hidden_features = next((child.out_features for child in reversed(list(hidden_net.children())) if
-                                hasattr(child, 'out_features')), None)
+            assert hidden_features == inferred_hidden_features, (
+                f"hidden_features={hidden_features} does not match inferred value "
+                f"{inferred_hidden_features} from hidden_net."
+            )
+        else:
+            hidden_features = inferred_hidden_features
 
         super().__init__()
 

--- a/pyknos/mdn/mdn.py
+++ b/pyknos/mdn/mdn.py
@@ -31,9 +31,9 @@ class MultivariateGaussianMDN(nn.Module):
         self,
         features: int,
         context_features: int,
+        hidden_net: nn.Module,
+        num_components: int,
         hidden_features: int = None,
-        hidden_net: nn.Module = None,
-        num_components: int = None,
         custom_initialization=False,
         embedding_net=None,
     ):

--- a/pyknos/mdn/mdn.py
+++ b/pyknos/mdn/mdn.py
@@ -49,11 +49,6 @@ class MultivariateGaussianMDN(nn.Module):
             custom_initialization: XXX
         """
 
-        if hidden_net is None:
-            raise TypeError("__init__() missing 1 required positional argument: 'hidden_net'")
-        if num_components is None:
-            raise TypeError("__init__() missing 1 required positional argument: 'num_components'")
-
         if hidden_features is not None:
             msg = "'hidden_features' parameter is deprecated and will be removed in a future version.\n"
             warnings.warn(msg, DeprecationWarning, stacklevel=2)


### PR DESCRIPTION
# Deprecated parameter `hidden_features` in [mdn.py](https://github.com/mackelab/pyknos/blob/main/pyknos/mdn/mdn.py)

## Problem Description
Previously users were required to pass in `hidden_features` which is un-necessary and introduces the following problems
- Users are required to keep track of their `hidden_net` output in their code in order to pass it properly which adds unnecessary overhead on the user.
- In the case that the user passes a wrong `hidden_features` that doesn't match `hidden_net` output the code fails.

## Proposed Solution
Instead of requiring the user to provide `hidden_features`, the code should infer `hidden_features` from `hidden_net`.

## Other Considerations
Code has to maintain backwards compatibility with code that is maybe using `hidden_features` as a positional argument.

This is done by converting `hidden_features`, `hidden_net`, `num_components` into kwargs and manually checking for their existence. 

## Misc
added `.idea/` to `.gitignore` to support Idea IDEs